### PR TITLE
WizardOutput: Fix wrong tag name

### DIFF
--- a/components/WizardOutput.js
+++ b/components/WizardOutput.js
@@ -179,7 +179,7 @@ const versionInfo = {
     scaleVersion: '3',
     scaleInfoVersion: '2.6',
     brushDeclaration: (features) =>
-        `openbrush = { tag = "v4.0.0-beta", git = "https://github.com/Brushfam/openbrush-contracts", default-features = false, features = [${features}] }`
+        `openbrush = { tag = "4.0.0-beta", git = "https://github.com/Brushfam/openbrush-contracts", default-features = false, features = [${features}] }`
   }
 }
 


### PR DESCRIPTION
The default generated Cargo.toml does not compile as the tag version was incorrectly set to "v4.0.0-beta" instead of "4.0.0-beta"