### PR TITLE
WizardOutput: Fix minting function

### DIFF
--- a/components/WizardOutput.js
+++ b/components/WizardOutput.js
@@ -302,7 +302,7 @@ export const generateLib = (output, version = 'v4.0.0-beta') => {
       )
     else
       contract.addConstructorAction(
-          `psp22::Internal::_mint(&mut _instance, Self::env().caller(), initial_supply).expect("Should mint"); `
+          `psp22::Internal::_mint_to(&mut _instance, Self::env().caller(), initial_supply).expect("Should mint"); `
       )
   }
 


### PR DESCRIPTION
In 4.0.0-beta the compiler is complaining about '_mint' function not existing. Instead it suggests to use '_min_to'.

Moreover, in newer Rust versions, there is also an error regarding the use of 'psp32::Internal' as it should be marked as a dyn objects '<dyn psp22::Internal>'. I'm not sure what's the current supported Rust version so I haven't added that change to this pull request.