### PR TITLE
Cargo.toml tag reference should not include leading 'v' as it leads to build failure

### DIFF
--- a/components/WizardOutput.js
+++ b/components/WizardOutput.js
@@ -94,7 +94,7 @@ const versionInfo = {
     scaleVersion: '2.1',
     scaleInfoVersion: '1.0.0',
     brushDeclaration: (features) =>
-      `brush = { tag = "v1.3.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = [${features}] }`
+      `brush = { tag = "1.3.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = [${features}] }`
   },
   'v1.5.0': {
     edition: '2021',
@@ -102,7 +102,7 @@ const versionInfo = {
     scaleVersion: '3.0',
     scaleInfoVersion: '2.0.0',
     brushDeclaration: (features) =>
-      `brush = { tag = "v1.5.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = [${features}] }`
+      `brush = { tag = "1.5.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = [${features}] }`
   },
   'v1.6.0': {
     edition: '2021',
@@ -110,7 +110,7 @@ const versionInfo = {
     scaleVersion: '3.0',
     scaleInfoVersion: '2.0.0',
     brushDeclaration: (features) =>
-      `brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = [${features}] }`
+      `brush = { tag = "1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = [${features}] }`
   },
   'v1.7.0': {
     edition: '2021',
@@ -147,7 +147,7 @@ const versionInfo = {
     scaleVersion: '3',
     scaleInfoVersion: '2',
     brushDeclaration: (features) =>
-      `openbrush = { tag = "v2.3.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = [${features}] }`
+      `openbrush = { tag = "2.3.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = [${features}] }`
   },
   'v3.0.0-beta': {
     edition: '2021',
@@ -179,7 +179,7 @@ const versionInfo = {
     scaleVersion: '3',
     scaleInfoVersion: '2.6',
     brushDeclaration: (features) =>
-        `openbrush = { tag = "v4.0.0-beta", git = "https://github.com/Brushfam/openbrush-contracts", default-features = false, features = [${features}] }`
+        `openbrush = { tag = "4.0.0-beta", git = "https://github.com/Brushfam/openbrush-contracts", default-features = false, features = [${features}] }`
   }
 }
 


### PR DESCRIPTION
`openbrush = { tag = "v4.0.0-beta", git = "https://github.com/Brushfam/openbrush-contracts", default-features = false, features = ["psp22"] }`

```
ERROR: Error invoking `cargo metadata` for Cargo.toml

Caused by:
    `cargo metadata` exited with an error:     Updating git repository `https://github.com/Brushfam/openbrush-contracts`
    error: failed to get `openbrush` as a dependency of package `staking_contract v0.1.0 (/Users/connorcampbell/Dev/ink/staking_contract)`
    
    Caused by:
      failed to load source for dependency `openbrush`
    
    Caused by:
      Unable to update https://github.com/Brushfam/openbrush-contracts?tag=v4.0.0-beta
    
    Caused by:
      failed to find tag `v4.0.0-beta`
    
    Caused by:
      reference 'refs/remotes/origin/tags/v4.0.0-beta' not found; class=Reference (4); code=NotFound (-3)

```